### PR TITLE
Always show size indicator

### DIFF
--- a/Assets/Sculpting/Prefabs/UI/ToolSizeIndicator/ToolSizeIndicatorUI.prefab
+++ b/Assets/Sculpting/Prefabs/UI/ToolSizeIndicator/ToolSizeIndicatorUI.prefab
@@ -124,7 +124,7 @@ LineRenderer:
     shadowBias: 0.5
     generateLightingData: 0
   m_UseWorldSpace: 0
-  m_Loop: 0
+  m_Loop: 1
 --- !u!114 &5791725182254768568
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Sculpting/Scripts/UI/ToolSizeIndicator/ToolSizeIndicatorUI.cs
+++ b/Assets/Sculpting/Scripts/UI/ToolSizeIndicator/ToolSizeIndicatorUI.cs
@@ -47,8 +47,8 @@ namespace VRSculpting.UI.ToolSizeIndicator {
 		private void Update() {
 			transform.rotation = Quaternion.LookRotation(Camera.main.transform.position - transform.position);
 
-			float targetAlpha = Time.time - lastChange <= activeDuration ? 1f : 0f;
-			alpha += (targetAlpha - alpha) * .25f;
+			float targetAlpha = Time.time - lastChange <= activeDuration ? 1f : .035f;
+			alpha += (targetAlpha - alpha) * .1f;
 			lineRenderer.startColor = lineRenderer.endColor = new Color(1, 1, 1, alpha);
 		}
 

--- a/Assets/Sculpting/Scripts/UI/ToolSizeIndicator/ToolSizeIndicatorUI.cs
+++ b/Assets/Sculpting/Scripts/UI/ToolSizeIndicator/ToolSizeIndicatorUI.cs
@@ -6,7 +6,7 @@ namespace VRSculpting.UI.ToolSizeIndicator {
 	[RequireComponent(typeof(LineRenderer))]
 	public class ToolSizeIndicatorUI : UI {
 
-		private static int resolution = 64;
+		private static int resolution = 96;
 		private static float step = (2 * Mathf.PI) / resolution;
 		private static float lineWidth = .001f;
 		private static float activeDuration = .5f;

--- a/Assets/Sculpting/Scripts/UI/ToolSizeIndicator/ToolSizeIndicatorUI.cs
+++ b/Assets/Sculpting/Scripts/UI/ToolSizeIndicator/ToolSizeIndicatorUI.cs
@@ -24,7 +24,7 @@ namespace VRSculpting.UI.ToolSizeIndicator {
 		}
 
 		public override void Init(Menu menu) {
-			points = new Vector3[resolution + 2];
+			points = new Vector3[resolution];
 			for (int i = 0; i < points.Length; i++) {
 				float angle = i * step;
 				points[i] = new Vector3(


### PR DESCRIPTION
There now is a transparent circle around the right controller indicating the size of the tool's effect area. This circle used to be only shown when the tool size was being changed.