### PR TITLE
Fix desktop mode

### DIFF
--- a/Assets/Sculpting/Scripts/Sculptor/Desktop/DesktopSculptor.cs
+++ b/Assets/Sculpting/Scripts/Sculptor/Desktop/DesktopSculptor.cs
@@ -16,10 +16,15 @@ namespace VRSculpting.Sculptor.Desktop
 
         private Vector3 activePosition;
 
-        private void Awake()
+        public override void Init(SculptMesh.Modification.SculptMesh sculptMesh, Settings.Menu menu)
         {
+            base.Init(sculptMesh, menu);
+
             if (camRigPrefab == null) Debug.LogError(@"Camera rig reference not found on ""DesktopSculptor""");
             camRig = Instantiate(camRigPrefab);
+
+            var coll = MeshWrapper.MeshTransform.gameObject.AddComponent<SphereCollider>();
+            coll.radius = MeshWrapper.radius;
         }
 
         protected override SculptState GetState(SculptState prev)

--- a/Assets/Sculpting/Scripts/Sculptor/SculptorBehaviour.cs
+++ b/Assets/Sculpting/Scripts/Sculptor/SculptorBehaviour.cs
@@ -4,7 +4,6 @@ using UnityEngine;
 
 namespace VRSculpting.Sculptor
 {
-    using Tools;
     using SculptMesh;
     using SculptMesh.Modification;
     using Settings;


### PR DESCRIPTION
Fixes #21.
Adds a collider to the mesh in desktop mode. This allows raycasting on the mesh surface.